### PR TITLE
refactor: enhance dataset path resolution and update training scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
           pip install --no-build-isolation ".[dev]"
 
       - name: Train models and run tests
+        env:
+          YTS_PROJECT_ROOT: ${{ github.workspace }}
+          YTS_DATA_PATH: ${{ github.workspace }}/data/Global YouTube Statistics.csv
+          YTS_ARTIFACT_DIR: ${{ github.workspace }}/artifacts
         run: |
           python -m youtube_success_ml.train --run-all
           pytest -q

--- a/src/youtube_success_ml/train.py
+++ b/src/youtube_success_ml/train.py
@@ -4,13 +4,12 @@ import argparse
 import json
 
 from youtube_success_ml.config import (
-    DEFAULT_DATA_PATH,
     MAP_DIR,
     MODEL_DIR,
     REPORT_DIR,
     TrainingConfig,
 )
-from youtube_success_ml.data.loader import load_dataset, load_raw_dataset
+from youtube_success_ml.data.loader import load_dataset, load_raw_dataset, resolve_data_path
 from youtube_success_ml.logging_utils import configure_logging
 from youtube_success_ml.mlops.drift import build_training_baseline, save_training_baseline
 from youtube_success_ml.mlops.quality import build_data_quality_report, save_data_quality_report
@@ -27,8 +26,9 @@ from youtube_success_ml.visualization.maps import export_map_assets
 
 def run_training(run_maps: bool = True) -> dict:
     cfg = TrainingConfig.from_env()
-    raw_df = load_raw_dataset()
-    df = load_dataset()
+    data_path = resolve_data_path()
+    raw_df = load_raw_dataset(path=data_path)
+    df = load_dataset(path=data_path)
 
     supervised = train_supervised_bundle(df, config=cfg, model_dir=MODEL_DIR)
     clustering, _ = train_clustering_bundle(df, config=cfg, model_dir=MODEL_DIR)
@@ -54,7 +54,7 @@ def run_training(run_maps: bool = True) -> dict:
         run_id=run_id,
         config=cfg,
         metrics=metrics,
-        data_path=DEFAULT_DATA_PATH,
+        data_path=data_path,
         model_dir=MODEL_DIR,
         report_dir=REPORT_DIR,
     )

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+
+from youtube_success_ml.data.loader import resolve_data_path
+
+
+def test_resolve_data_path_from_cwd_data_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    dataset_dir = tmp_path / "data"
+    dataset_dir.mkdir(parents=True, exist_ok=True)
+    dataset_path = dataset_dir / "Global YouTube Statistics.csv"
+    dataset_path.write_text("uploads,category,country\n1,Education,United States\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("YTS_DATA_PATH", raising=False)
+
+    resolved = resolve_data_path()
+    assert resolved == dataset_path
+
+
+def test_resolve_data_path_raises_for_missing_explicit_path(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        resolve_data_path(tmp_path / "missing.csv")


### PR DESCRIPTION
This pull request improves the reliability and flexibility of dataset path resolution across different environments (local, development, CI) and adds tests to ensure correct behavior. The main changes include refactoring how paths are resolved in the configuration and data loading modules, updating training logic to use the new resolution method, and introducing tests for path resolution.

**Path resolution improvements:**

* Added a more robust `_resolve_project_root` function in `config.py` to determine the project root by checking environment variables and common directory structures, with support for overrides via environment variables.
* Refactored `DEFAULT_DATA_PATH`, `ARTIFACT_DIR`, and related paths in `config.py` to use the resolved project root and allow environment variable overrides.
* Implemented `resolve_data_path` in `loader.py` to search for the dataset file in multiple likely locations, handling explicit paths, and raising clear errors if not found.
* Updated all usages of the dataset path in `train.py` to use `resolve_data_path`, ensuring consistent path resolution. [[1]](diffhunk://#diff-14bbe1ce6c57e5be9103c95a01e016a1e0c73da4437fba50c5e3971e57aa7eedL7-R12) [[2]](diffhunk://#diff-14bbe1ce6c57e5be9103c95a01e016a1e0c73da4437fba50c5e3971e57aa7eedL30-R31) [[3]](diffhunk://#diff-14bbe1ce6c57e5be9103c95a01e016a1e0c73da4437fba50c5e3971e57aa7eedL57-R57)

**Testing:**

* Added `test_path_resolution.py` to verify that `resolve_data_path` correctly finds the dataset in typical locations and raises errors when expected.

**CI/CD configuration:**

* Updated the GitHub Actions workflow to set environment variables for project root, data path, and artifact directory, ensuring consistent paths during CI runs.