### PR TITLE
Fix grid responsiveness and style code blocks as macOS windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -901,55 +901,91 @@ flowchart LR
         <div class="runbook-grid">
           <article class="runbook-card reveal searchable" data-search="local bootstrap train test">
             <h3>Local ML + API Bootstrap</h3>
-            <pre id="cmd-local"><code>source .venv/bin/activate
+            <div class="code-window">
+              <div class="code-window-header">
+                <div class="code-window-dots"><span></span><span></span><span></span></div>
+                <span class="code-window-title">Terminal</span>
+                <button class="copy-btn" data-copy-target="cmd-local" type="button">Copy</button>
+              </div>
+              <pre id="cmd-local"><code>source .venv/bin/activate
 PYTHONPATH=src python -m youtube_success_ml.train --run-all
 PYTHONPATH=src pytest -q
 PYTHONPATH=src uvicorn youtube_success_ml.api.fastapi_app:app --host 0.0.0.0 --port 8000</code></pre>
-            <button class="copy-btn" data-copy-target="cmd-local" type="button">Copy</button>
+            </div>
           </article>
           <article class="runbook-card reveal searchable" data-search="frontend dev build lint">
             <h3>Frontend Lifecycle</h3>
-            <pre id="cmd-frontend"><code>cd frontend
+            <div class="code-window">
+              <div class="code-window-header">
+                <div class="code-window-dots"><span></span><span></span><span></span></div>
+                <span class="code-window-title">Terminal</span>
+                <button class="copy-btn" data-copy-target="cmd-frontend" type="button">Copy</button>
+              </div>
+              <pre id="cmd-frontend"><code>cd frontend
 npm ci
 npm run lint
 npm run build
 npm run dev</code></pre>
-            <button class="copy-btn" data-copy-target="cmd-frontend" type="button">Copy</button>
+            </div>
           </article>
           <article
             class="runbook-card reveal searchable"
             data-search="kubernetes render validate overlays"
           >
             <h3>Kubernetes Render Checks</h3>
-            <pre id="cmd-k8s"><code>kubectl kustomize infra/k8s/overlays/rolling
+            <div class="code-window">
+              <div class="code-window-header">
+                <div class="code-window-dots"><span></span><span></span><span></span></div>
+                <span class="code-window-title">Terminal</span>
+                <button class="copy-btn" data-copy-target="cmd-k8s" type="button">Copy</button>
+              </div>
+              <pre id="cmd-k8s"><code>kubectl kustomize infra/k8s/overlays/rolling
 kubectl kustomize infra/k8s/overlays/canary
 kubectl kustomize infra/k8s/overlays/bluegreen</code></pre>
-            <button class="copy-btn" data-copy-target="cmd-k8s" type="button">Copy</button>
+            </div>
           </article>
           <article class="runbook-card reveal searchable" data-search="argo strategy switching">
             <h3>Argo Strategy Switching</h3>
-            <pre id="cmd-argo"><code>bash infra/argocd/bootstrap.sh
+            <div class="code-window">
+              <div class="code-window-header">
+                <div class="code-window-dots"><span></span><span></span><span></span></div>
+                <span class="code-window-title">Terminal</span>
+                <button class="copy-btn" data-copy-target="cmd-argo" type="button">Copy</button>
+              </div>
+              <pre id="cmd-argo"><code>bash infra/argocd/bootstrap.sh
 bash infra/argocd/switch-strategy.sh canary
 bash infra/argocd/switch-strategy.sh bluegreen
 bash infra/argocd/switch-strategy.sh rolling</code></pre>
-            <button class="copy-btn" data-copy-target="cmd-argo" type="button">Copy</button>
+            </div>
           </article>
           <article
             class="runbook-card reveal searchable"
             data-search="terraform aws gcp azure oci plan"
           >
             <h3>Terraform Apply Pattern</h3>
-            <pre id="cmd-tf"><code>cd infra/terraform/environments/aws
+            <div class="code-window">
+              <div class="code-window-header">
+                <div class="code-window-dots"><span></span><span></span><span></span></div>
+                <span class="code-window-title">Terminal</span>
+                <button class="copy-btn" data-copy-target="cmd-tf" type="button">Copy</button>
+              </div>
+              <pre id="cmd-tf"><code>cd infra/terraform/environments/aws
 cp terraform.tfvars.example terraform.tfvars
 terraform init
 terraform plan
 terraform apply</code></pre>
-            <button class="copy-btn" data-copy-target="cmd-tf" type="button">Copy</button>
+            </div>
           </article>
           <article class="runbook-card reveal searchable" data-search="docker compose local stack">
             <h3>Container Stack</h3>
-            <pre id="cmd-compose"><code>docker compose up --build</code></pre>
-            <button class="copy-btn" data-copy-target="cmd-compose" type="button">Copy</button>
+            <div class="code-window">
+              <div class="code-window-header">
+                <div class="code-window-dots"><span></span><span></span><span></span></div>
+                <span class="code-window-title">Terminal</span>
+                <button class="copy-btn" data-copy-target="cmd-compose" type="button">Copy</button>
+              </div>
+              <pre id="cmd-compose"><code>docker compose up --build</code></pre>
+            </div>
           </article>
         </div>
       </section>
@@ -1077,27 +1113,51 @@ terraform apply</code></pre>
         <div class="runbook-grid">
           <article class="runbook-card reveal searchable" data-search="smoke api verify">
             <h3>Smoke API</h3>
-            <pre><code>bash scripts/smoke_api.sh http://127.0.0.1:8000</code></pre>
+            <div class="code-window">
+              <div class="code-window-header">
+                <div class="code-window-dots"><span></span><span></span><span></span></div>
+                <span class="code-window-title">Terminal</span>
+              </div>
+              <pre><code>bash scripts/smoke_api.sh http://127.0.0.1:8000</code></pre>
+            </div>
           </article>
           <article class="runbook-card reveal searchable" data-search="ready endpoint verify">
             <h3>Readiness Verification</h3>
-            <pre><code>curl -i http://127.0.0.1:8000/ready</code></pre>
+            <div class="code-window">
+              <div class="code-window-header">
+                <div class="code-window-dots"><span></span><span></span><span></span></div>
+                <span class="code-window-title">Terminal</span>
+              </div>
+              <pre><code>curl -i http://127.0.0.1:8000/ready</code></pre>
+            </div>
           </article>
           <article
             class="runbook-card reveal searchable"
             data-search="jenkins parameters provider strategy"
           >
             <h3>Jenkins Inputs</h3>
-            <pre><code>CLOUD_PROVIDER=(aws|gcp|azure|oci)
+            <div class="code-window">
+              <div class="code-window-header">
+                <div class="code-window-dots"><span></span><span></span><span></span></div>
+                <span class="code-window-title">Terminal</span>
+              </div>
+              <pre><code>CLOUD_PROVIDER=(aws|gcp|azure|oci)
 DEPLOY_STRATEGY=(rolling|canary|bluegreen)
 RUN_TERRAFORM_APPLY=(true|false)
 IMAGE_TAG=(optional)</code></pre>
+            </div>
           </article>
           <article class="runbook-card reveal searchable" data-search="incident response rollback">
             <h3>Incident Response</h3>
-            <pre><code>kubectl argo rollouts abort yts-api -n yts-prod
+            <div class="code-window">
+              <div class="code-window-header">
+                <div class="code-window-dots"><span></span><span></span><span></span></div>
+                <span class="code-window-title">Terminal</span>
+              </div>
+              <pre><code>kubectl argo rollouts abort yts-api -n yts-prod
 kubectl argo rollouts abort yts-frontend -n yts-prod
 kubectl argo rollouts undo yts-api -n yts-prod</code></pre>
+            </div>
           </article>
         </div>
       </section>

--- a/info/styles.css
+++ b/info/styles.css
@@ -582,35 +582,104 @@ a {
   padding: 1rem;
 }
 
-.runbook-card pre {
-  margin: 0.7rem 0 0;
-  background: rgba(6, 12, 24, 0.85);
-  border-radius: var(--radius-sm);
-  border: 1px solid rgba(166, 186, 233, 0.2);
-  padding: 0.75rem;
-  overflow-x: auto;
-}
-
 .runbook-card code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   color: #d4e1ff;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.runbook-card pre {
+  margin: 0;
+  background: rgba(6, 12, 24, 0.92);
+  padding: 0.85rem;
+  overflow-x: auto;
+  border: none;
+  border-radius: 0 0 10px 10px;
+}
+
+.code-window {
+  margin-top: 0.7rem;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid rgba(166, 186, 233, 0.2);
+  background: rgba(6, 12, 24, 0.92);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+}
+
+.code-window-header {
+  display: flex;
+  align-items: center;
+  padding: 0.55rem 0.75rem;
+  background: linear-gradient(180deg, rgba(40, 52, 78, 0.7), rgba(30, 42, 65, 0.6));
+  border-bottom: 1px solid rgba(166, 186, 233, 0.1);
+  gap: 0.5rem;
+}
+
+.code-window-dots {
+  display: flex;
+  gap: 7px;
+  flex-shrink: 0;
+}
+
+.code-window-dots span {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.code-window-dots span:nth-child(1) {
+  background: #ff5f57;
+}
+
+.code-window-dots span:nth-child(2) {
+  background: #febc2e;
+}
+
+.code-window-dots span:nth-child(3) {
+  background: #28c840;
+}
+
+.code-window-title {
+  flex: 1;
+  text-align: center;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  opacity: 0.7;
+  user-select: none;
 }
 
 .copy-btn {
-  margin-top: 0.65rem;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 0.42rem 0.72rem;
-  background: rgba(79, 149, 255, 0.18);
-  color: var(--text);
+  border: 1px solid rgba(166, 186, 233, 0.22);
+  border-radius: 6px;
+  padding: 0.22rem 0.55rem;
+  background: rgba(79, 149, 255, 0.14);
+  color: var(--text-dim);
   cursor: pointer;
   font-weight: 600;
-  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  font-size: 0.75rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  flex-shrink: 0;
+  transition: all 0.2s ease;
+}
+
+.copy-btn:hover {
+  background: rgba(79, 149, 255, 0.28);
+  color: var(--text);
+  border-color: rgba(166, 186, 233, 0.4);
 }
 
 .copy-btn.copied {
   background: rgba(106, 224, 164, 0.2);
   border-color: rgba(106, 224, 164, 0.45);
+  color: var(--ok);
+}
+
+.code-window pre {
+  margin: 0;
+  border: none;
+  border-radius: 0;
 }
 
 .timeline {
@@ -851,7 +920,7 @@ a {
   .feature-card,
   .chart-card,
   .runbook-card,
-  .doc-card {
+  .docs-grid .doc-card {
     grid-column: span 6;
   }
 }
@@ -934,7 +1003,7 @@ a {
   .feature-card,
   .chart-card,
   .runbook-card,
-  .doc-card {
+  .docs-grid .doc-card {
     grid-column: span 12;
   }
 


### PR DESCRIPTION
- Fix CSS specificity bug: .docs-grid .doc-card (0,2,0) was overriding media query .doc-card (0,1,0), keeping 3 cards/row on all screen sizes. Now properly collapses to 2 cards at 1060px and 1 card at 780px.
- Wrap all runbook code blocks in macOS-style terminal windows with traffic light dots, centered title, and header-integrated copy button.
- Style 10 code blocks across Runbook and Ops Playbook sections.